### PR TITLE
Fix for hard-coded bugzilla url

### DIFF
--- a/pytest_marker_bugzilla.py
+++ b/pytest_marker_bugzilla.py
@@ -129,7 +129,9 @@ class BugzillaHooks(object):
                 will_skip = False
             else:
                 skippers.append(bug)
-        url = "https://bugzilla.redhat.com/show_bug.cgi?id="
+        url = "{0}?id=".format(
+            self.bugzilla.url.replace("xmlrpc.cgi", "show_bug.cgi"),
+        )
 
         if will_skip:
             pytest.skip(


### PR DESCRIPTION
The skipped testcase was pointing to hard coded url of bugzilla site, regardless of bugzilla_url parameter.