### PR TITLE
BugzillaBugs.bugs_gen lookup bugs in cache first

### DIFF
--- a/pytest_marker_bugzilla.py
+++ b/pytest_marker_bugzilla.py
@@ -108,23 +108,23 @@ class BugzillaBugs(object):
     @property
     def bugs_gen(self):
         for bug_id in self.bug_ids:
-            bug = BugWrapper(self.bugzilla.getbug(bug_id), self.loose)
             if bug_id not in _bugs_pool:
+                bug = BugWrapper(self.bugzilla.getbug(bug_id), self.loose)
                 _bugs_pool[bug_id] = bug
             yield _bugs_pool[bug_id]
 
     def bug(self, id):
         """Returns Bugzilla's Bug object for given ID"""
         id = int(id)
+        if id not in self.bug_ids:
+            raise ValueError("Could not find bug with id {0}".format(id))
+
         if id in _bugs_pool:
             return _bugs_pool[id]
-        for bug_id in self.bug_ids:
-            if id == bug_id:
-                bug = BugWrapper(self.bugzilla.getbug(bug_id), self.loose)
-                _bugs_pool[bug_id] = bug
-                return bug
-        else:
-            raise ValueError("Could not find bug with id {0}".format(id))
+
+        bug = BugWrapper(self.bugzilla.getbug(id), self.loose)
+        _bugs_pool[id] = bug
+        return bug
 
 
 class BugzillaHooks(object):


### PR DESCRIPTION
The problem was that BugzillaBugs.bugs_gen was pulling bug from Bugzilla
site regardless of cache content.

Minor fix: Simplified logic of BugzillaBugs.bug method.