### PR TITLE
Improve unittests structure

### DIFF
--- a/pytest_marker_bugzilla.py
+++ b/pytest_marker_bugzilla.py
@@ -108,8 +108,8 @@ class BugzillaBugs(object):
     @property
     def bugs_gen(self):
         for bug_id in self.bug_ids:
-            bug = BugWrapper(self.bugzilla.getbug(bug_id), self.loose)
             if bug_id not in _bugs_pool:
+                bug = BugWrapper(self.bugzilla.getbug(bug_id), self.loose)
                 _bugs_pool[bug_id] = bug
             yield _bugs_pool[bug_id]
 
@@ -133,6 +133,10 @@ class BugzillaHooks(object):
         self.bugzilla = bugzilla
         self.version = version
         self.loose = loose
+
+    def add_bug_to_cache(self, bug_obj):
+        """For test purposes only"""
+        _bugs_pool[bug_obj.id] = BugWrapper(bug_obj, self.loose)
 
     def pytest_runtest_setup(self, item):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,21 @@
+import sys
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_suite = True
+        self.test_args = "-s tests/"
+
+    def run_tests(self):
+        #import here, cause outside the eggs aren't loaded elsewhere
+        import pytest
+        print "Running: pytest %s" % self.test_args
+        sys.path.insert(0, 'lib')
+        pytest.main(self.test_args)
+
 
 setup(
     name="pytest-marker-bugzilla",
@@ -7,23 +24,26 @@ setup(
     long_description=open('README.txt').read(),
     license='GPL',
     author='Eric Sammons',
-    author_email='elsammons@gmail.com' ,
+    author_email='elsammons@gmail.com',
     url='http://github.com/eanxgeek/pytest_marker_bugzilla',
     platforms=['linux', 'osx', 'win32'],
     py_modules=['pytest_marker_bugzilla'],
-    entry_points = {'pytest11': ['pytest_marker_bugzilla = pytest_marker_bugzilla'],},
+    entry_points={
+        'pytest11': ['pytest_marker_bugzilla = pytest_marker_bugzilla'],
+    },
     zip_safe=False,
-    install_requires = ['python-bugzilla>=0.6.2','pytest>=2.2.4'],
+    install_requires=['python-bugzilla>=0.6.2', 'pytest>=2.2.4'],
     classifiers=[
-    'Development Status :: 3 - Alpha',
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: GNU General Public License (GPL)',
-    'Operating System :: POSIX',
-    'Operating System :: Microsoft :: Windows',
-    'Operating System :: MacOS :: MacOS X',
-    'Topic :: Software Development :: Testing',
-    'Topic :: Software Development :: Quality Assurance',
-    'Topic :: Utilities',
-    'Programming Language :: Python',
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU General Public License (GPL)',
+        'Operating System :: POSIX',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: MacOS :: MacOS X',
+        'Topic :: Software Development :: Testing',
+        'Topic :: Software Development :: Quality Assurance',
+        'Topic :: Utilities',
+        'Programming Language :: Python',
     ],
+    cmdclass={'test': PyTest,},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+from collections import namedtuple
+import pytest
+
+
+FAKE_BUGS = {
+    "1": {
+        "id": 1,
+        "version": None,
+        "fixed_in": None,
+        "status": 'NEW',
+        "target_release": None,
+    },
+    "2": {
+        "id": 2,
+        "version": None,
+        "fixed_in": None,
+        "status": 'CLOSED',
+        "target_release": None,
+    },
+}
+
+
+# Create fake bug class
+FakeBug = namedtuple('FakeBug', FAKE_BUGS['1'].keys())
+
+
+@pytest.mark.tryfirst
+def pytest_collection_modifyitems(session, config, items):
+    plug = config.pluginmanager.getplugin('bugzilla_helper')
+    if not plug:  # First run of pytest
+        return
+    for bug in FAKE_BUGS.values():
+        plug.add_bug_to_cache(FakeBug(**bug))

--- a/tests/test_bugzilla.py.in
+++ b/tests/test_bugzilla.py.in
@@ -1,24 +1,26 @@
-import pytest
+"""
+This is test case to test bugzilla plugin.
+"""
 import os
-import xmlrpclib
+import pytest
+
 
 @pytest.mark.skip_selenium
 @pytest.mark.nondestructive
-class TestNothin(object):
+class TestNothing(object):
 
-    @pytest.mark.bugzilla('824975')
+    @pytest.mark.bugzilla('1')
     def test_new_bz(self):
-        print('hello')
-        assert(os.path.exists('/etc'))
-        
-    @pytest.mark.bugzilla('12345')
+        assert(os.path.exists('/etcccc'))
+
+    @pytest.mark.bugzilla('2')
     def test_closed_bz(self):
         assert(os.path.exists('/etc'))
-           
-    @pytest.mark.bugzilla('12345')
+
+    @pytest.mark.bugzilla('2')
     def test_closed_bz_with_failure(self):
-        assert(os.path.exists('/etcccc')) 
-    
+        assert(os.path.exists('/etcccc'))
+
     def test_without_bugzilla(self):
         assert(os.path.exists('/etc'))
 

--- a/tests/test_nothing.py
+++ b/tests/test_nothing.py
@@ -1,0 +1,104 @@
+"""
+How to add new test?
+
+There is file called test_bugzilla.py.in, this file contains real usage
+of bugzilla plugin.
+It uses bugzilla mark and does its job.
+
+In this file we have same test cases as in test_bugzilla.py.in,
+but here we test whether test case from test_bugzilla.py.in has expected
+result.
+
+If you want to add new test into both files, one test bugzilla mark,
+and second verify expected result.
+
+NOTE: if you want to use different bug ID, please add it to conftests.py
+"""
+import os
+import re
+import sys
+import subprocess
+import pytest
+
+
+@pytest.mark.skip_selenium
+@pytest.mark.nondestructive
+class TestNothing(object):
+
+    result_file = "results.txt"
+    test_file = os.path.join(os.path.dirname(__file__), "test_bugzilla.py")
+    results = None
+
+    @classmethod
+    def setup_class(cls):
+        # Create config file
+        config = "bugzilla.cfg"
+        assert os.path.exists(config), "please create bugzilla.cfg"
+
+        # Create test
+        with open(cls.test_file + ".in") as fhs:
+            with open(cls.test_file, 'w') as fht:
+                fht.write(fhs.read())
+
+        # Run test runner with plugin enabled
+        cmd = [
+            'py.test', '--bugzilla', '--result-log=%s' % cls.result_file,
+            cls.test_file,
+        ]
+        env = os.environ.copy()
+        env['PYTHONPATH'] = ":".join(sys.path)
+        p = subprocess.Popen(
+            subprocess.list2cmdline(cmd),
+            shell=True,
+            env=env,
+        )
+        p.communicate()
+        assert os.path.exists(cls.result_file)
+
+        # Read results of tests
+        with open(cls.result_file) as fh:
+            data = fh.read()
+        regex = re.compile("^(?P<code>[sfex.]) (?P<name>.+)\n", re.I | re.M)
+        cls.results = dict(
+            (m.group('name').split("::")[-1], m.group('code'))
+            for m in regex.finditer(data)
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        if os.path.exists(cls.test_file):
+            os.unlink(cls.test_file)
+
+    def _assert_result(self, expected, test_name):
+        status = self.results[test_name]
+        assert status == expected
+
+    def test_new_bz(self):
+        """
+        New bug, test-case should be skipped.
+        """
+        self._assert_result('s', 'test_new_bz')
+
+    def test_closed_bz(self):
+        """
+        Closed bug, passing test-case, it should pass.
+        """
+        self._assert_result('.', 'test_closed_bz')
+
+    def test_closed_bz_with_failure(self):
+        """
+        Closed bug, failing test-case, it should fail.
+        """
+        self._assert_result('F', 'test_closed_bz_with_failure')
+
+    def test_without_bugzilla(self):
+        """
+        No decorator, passsing test-case, it should pass
+        """
+        self._assert_result('.', 'test_without_bugzilla')
+
+    def test_fail_without_bugzilla(self):
+        """
+        No decorator, failing test-case, it should fail.
+        """
+        self._assert_result('F', 'test_fail_without_bugzilla')


### PR DESCRIPTION
1) Bugzilla server
We can not relay on status of bug from public bugzilla site.
Such bug can get closed, removed, or it may become unavailable.
I it better to feed cache with collection of our bugs.
Then we can be sure that bug has always same status as we expect.

2) 'test' target in setup.py
Added new target to setup.py to run tests.

python setup.py test

3) Test must give you information about quality
We can not accept result which has 2 pass and 2 failures and 1 skip,
and say that this is correct result of this test run.
Usual expected result of test is all test-cases passing.

Minor fix: Align setup.py with pep8