### PR TITLE
Fix travis build for py26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
     - "2.7"
     - "3.4"
 install:
-    - pip install tox
+    - pip install tox tox-travis
 script:
     - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
 envlist = py26,py27,py34,pep8
+[tox:travis]
+2.6 = py26
+2.7 = py27, pep8
+3.4 = py34, pep8
 [testenv]
 deps=
   pytest


### PR DESCRIPTION
The thing is that flake8 command dropped support for py26 and it started
to fail on dependency errors related to ordereddict.

Fix #31