### PR TITLE
Publish release on PyPI when tag is created

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,15 @@ install:
     - pip install tox tox-travis
 script:
     - tox
+deploy:
+  provider: pypi
+  user: "lukas-bednar"
+  password:
+    secure: "\
+      ks4q6t0YBc4i3hr5uYCepUi05SuBfkA6l2vakuqcQunuwClaCN3ryP5aKCKk3673wdKBh2ee\
+      L+VrKrmEnyRTrgo+t02ODSibAMeytwq254m526FiUbATemNrDyPtv7XTO/Yp9yFPwHbpoH8b\
+      dTa4MhTUm6qXcRtRdYvfU8zVKUU="
+  on:
+    branch: master
+    tags: true
+  skip_upload_docs: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name=pytest-marker-bugzilla
 summary=py.test bugzilla integration plugin, using markers
-description-file=README.txt
+description-file=README.rst
 license=GPL
 author=Eric Sammons, Lukas Bednar
 author_email=elsammons@gmail.com, lukyn17@gmail.com
@@ -36,3 +36,7 @@ pytest11 =
     pytest_marker_bugzilla = pytest_marker_bugzilla
 [global]
 zip_safe=True
+[bdist_wheel]
+universal = 1
+[sdist]
+formats = zip


### PR DESCRIPTION
This change enable release process on travis-ci when you create new release/tag.
More info about it here:
https://help.github.com/articles/creating-releases/
https://docs.travis-ci.com/user/deployment/pypi/

Fixes #34 