### PR TITLE
Pin pytest-xdist==1.21.0 for python 3.6.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ envlist = py{27,36}-pytest{361,431}
 [testenv]
 deps =
     pytest361: pytest==3.6.1
-    pytest431: pytest==4.3.1
-    pytest-xdist
+    pytest361: pytest-xdist==1.21.0
+    pytest431: pytest-xdist
     pytest-cov
 commands=
   pytest \


### PR DESCRIPTION
xdist > 1.21.0 required pytest > 4.4.0