### PR TITLE
change [metadata] description-file to long_description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name=pytest-marker-bugzilla
 summary=py.test bugzilla integration plugin, using markers
-description-file=README.rst
+long_description = file: README.rst
 license=GPL
 author=Eric Sammons, Lukas Bednar
 author_email=elsammons@gmail.com, lukyn17@gmail.com


### PR DESCRIPTION
fixes: https://github.com/els-pnw/pytest_marker_bugzilla/issues/55